### PR TITLE
Missing Semicolon

### DIFF
--- a/russian.md
+++ b/russian.md
@@ -567,7 +567,7 @@ $apiKey = config('api.key');
 
 ```
 // Модель
-protected $dates = ['ordered_at', 'created_at', 'updated_at']
+protected $dates = ['ordered_at', 'created_at', 'updated_at'];
 // Читатель (accessor)
 public function getSomeDateAttribute($date)
 {


### PR DESCRIPTION
Added missing semicolon in Store dates in the standard format. Use accessors and mutators to modify date format section (Russian)