### PR TITLE
Missing semicolon

### DIFF
--- a/persian.md
+++ b/persian.md
@@ -692,7 +692,7 @@ $apiKey = config('api.key');
 
 ```php
 // Model
-protected $dates = ['ordered_at', 'created_at', 'updated_at']
+protected $dates = ['ordered_at', 'created_at', 'updated_at'];
 public function getSomeDateAttribute($date)
 {
     return $date->format('m-d');


### PR DESCRIPTION
A missing semicolon in Store dates in the standard format. Use accessors and mutators to modify date format section (Persian)