### PR TITLE
Missing Semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Good:
 
 ```php
 // Model
-protected $dates = ['ordered_at', 'created_at', 'updated_at']
+protected $dates = ['ordered_at', 'created_at', 'updated_at'];
 public function getSomeDateAttribute($date)
 {
     return $date->format('m-d');


### PR DESCRIPTION
Missing semicolon in Store dates in the standard format. Use accessors and mutators to modify date format section (English)