### PR TITLE
Fixing "Deutsche" (Germans people) to "Deutsch" (german lang)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Translations:
 
 [Türkçe](turkish.md) (by [Burak](https://github.com/ikidnapmyself))
 
-[Deutsche](german.md) (by [Sujal Patel](https://github.com/sujalpatel2209))
+[Deutsch](german.md) (by [Sujal Patel](https://github.com/sujalpatel2209))
 
 [Italiana](italian.md) (by [Sujal Patel](https://github.com/sujalpatel2209))
 


### PR DESCRIPTION
Hey @alexeymezenin,

I've made a minor tweak to fix a grammar/typo issue.

Cheers,
Peter