### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Templates | Blade | Twig
 Working with data | Laravel collections | Arrays
 Form validation | Request classes | 3rd party packages, validation in controller
 Authentication | Built-in | 3rd party packages, your own solution
-API authentication | Laravel Passport | 3rd party JWT and OAuth packages
+API authentication | Laravel Passport, Laravel Sanctum | 3rd party JWT and OAuth packages
 Creating API | Built-in | Dingo API and similar packages
 Working with DB structure | Migrations | Working with DB structure directly
 Localization | Built-in | 3rd party packages


### PR DESCRIPTION
Adding Laravel Sanctum at the **API authentication** section of the Community accepted tools since it was added with v7.0 as a 
> featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs