### PR TITLE
Shorter optional() in php8

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Translations:
 
 [Français](french.md) (by [Mikayil S.](https://github.com/mikayilsrt))
 
-[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek), [Olsza](https://github.com/olsza))
+[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek))
 
 [Türkçe](turkish.md) (by [Burak](https://github.com/ikidnapmyself))
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Common syntax | Shorter and more readable syntax
 `Session::put('cart', $data)` | `session(['cart' => $data])`
 `$request->input('name'), Request::get('name')` | `$request->name, request('name')`
 `return Redirect::back()` | `return back()`
-`is_null($object->relation) ? null : $object->relation->id` | `optional($object->relation)->id`
+`is_null($object->relation) ? null : $object->relation->id` | `optional($object->relation)->id` (in PHP 8: `$object->relation?->id`)
 `return view('index')->with('title', $title)->with('client', $client)` | `return view('index', compact('title', 'client'))`
 `$request->has('value') ? $request->value : 'default';` | `$request->get('value', 'default')`
 `Carbon::now(), Carbon::today()` | `now(), today()`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Translations:
 
 [Français](french.md) (by [Mikayil S.](https://github.com/mikayilsrt))
 
-[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek))
+[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek), [Olsza](https://github.com/olsza))
 
 [Türkçe](turkish.md) (by [Burak](https://github.com/ikidnapmyself))
 

--- a/polish.md
+++ b/polish.md
@@ -32,7 +32,7 @@ Tłumaczenia:
 
 [Français](french.md) (by [Mikayil S.](https://github.com/mikayilsrt))
 
-[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek))
+[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek), [Olsza](https://github.com/olsza))
 
 [Türkçe](turkish.md) (by [Burak](https://github.com/ikidnapmyself))
 

--- a/polish.md
+++ b/polish.md
@@ -537,7 +537,7 @@ Powszechna składnia | Krótsza i bardziej czytelna składnia
 `Session::put('cart', $data)` | `session(['cart' => $data])`
 `$request->input('name'), Request::get('name')` | `$request->name, request('name')`
 `return Redirect::back()` | `return back()`
-`is_null($object->relation) ? null : $object->relation->id` | `optional($object->relation)->id`
+`is_null($object->relation) ? null : $object->relation->id` | `optional($object->relation)->id` (w PHP 8: `$object->relation?->id`)
 `return view('index')->with('title', $title)->with('client', $client)` | `return view('index', compact('title', 'client'))`
 `$request->has('value') ? $request->value : 'default';` | `$request->get('value', 'default')`
 `Carbon::now(), Carbon::today()` | `now(), today()`

--- a/polish.md
+++ b/polish.md
@@ -32,7 +32,7 @@ Tłumaczenia:
 
 [Français](french.md) (by [Mikayil S.](https://github.com/mikayilsrt))
 
-[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek), [Olsza](https://github.com/olsza))
+[Polski](polish.md) (by [Karol Pietruszka](https://github.com/pietrushek))
 
 [Türkçe](turkish.md) (by [Burak](https://github.com/ikidnapmyself))
 


### PR DESCRIPTION
Since the Nullsafe operator appeared in PHP8, you can further shorten the ```optional()``` method to ```?->```  :)