### PR TITLE
Use Array Instead Of Delimiter In Validation Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/arabic.md
+++ b/arabic.md
@@ -197,9 +197,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/bangla.md
+++ b/bangla.md
@@ -196,9 +196,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/chinese.md
+++ b/chinese.md
@@ -187,9 +187,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/french.md
+++ b/french.md
@@ -193,9 +193,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/german.md
+++ b/german.md
@@ -199,9 +199,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/indonesia.md
+++ b/indonesia.md
@@ -158,9 +158,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/italian.md
+++ b/italian.md
@@ -193,9 +193,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/japanese.md
+++ b/japanese.md
@@ -188,9 +188,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/persian.md
+++ b/persian.md
@@ -227,9 +227,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/polish.md
+++ b/polish.md
@@ -201,9 +201,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/russian.md
+++ b/russian.md
@@ -159,9 +159,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/spanish.md
+++ b/spanish.md
@@ -201,9 +201,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/thai.md
+++ b/thai.md
@@ -197,9 +197,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/traditional-chinese.md
+++ b/traditional-chinese.md
@@ -157,9 +157,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/turkish.md
+++ b/turkish.md
@@ -195,9 +195,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }

--- a/ukrainian.md
+++ b/ukrainian.md
@@ -159,9 +159,9 @@ class PostRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' =>  ['required','unique:posts','max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable','date'],
         ];
     }
 }


### PR DESCRIPTION
It is best practice to add validation rules in an array instead of using delimiters. We can use custom validation class