### PR TITLE
Array for validation rule values

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ Bad:
 public function store(Request $request)
 {
     $request->validate([
-        'title' => 'required|unique:posts|max:255',
-        'body' => 'required',
-        'publish_at' => 'nullable|date',
+        'title' => ['required', 'unique:posts', 'max:255'],
+        'body' => ['required'],
+        'publish_at' => ['nullable', 'date'],
     ]);
 
     ....
@@ -207,9 +207,9 @@ class PostRequest extends Request
     public function rules(): array
     {
         return [
-            'title' => 'required|unique:posts|max:255',
-            'body' => 'required',
-            'publish_at' => 'nullable|date',
+            'title' => ['required', 'unique:posts', 'max:255'],
+            'body' => ['required'],
+            'publish_at' => ['nullable', 'date'],
         ];
     }
 }


### PR DESCRIPTION
It is better to write validation rule values as array than as piped string. 
First reason is to have consistency regardless we have to involve custom rule class or not.