### PR TITLE
fix: attribute method return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ public function getFullNameAttribute()
 Good:
 
 ```php
-public function getFullNameAttribute(): bool
+public function getFullNameAttribute(): string
 {
     return $this->isVerifiedClient() ? $this->getFullNameLong() : $this->getFullNameShort();
 }


### PR DESCRIPTION
After checking whether the account is verified both the methods (getFullNameLong()  - getFullNameShort()) will return a (String) type 