### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ public function getSomeDateAttribute($date)
 
 // View
 {{ $object->ordered_at->toDateString() }}
-{{ $object->ordered_at->some_date }}
+{{ $object->some_date }}
 ```
 
 [🔝 Back to contents](#contents)


### PR DESCRIPTION
The example for date formats was wrong because it used the accessor on the `ordered_at` attribute instead of just the `$object`.