### PR TITLE
Change test case methods to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Primary key | - | id | ~~custom_id~~
 Migration | - | 2017_01_01_000000_create_articles_table | ~~2017_01_01_000000_articles~~
 Method | camelCase | getAll | ~~get_all~~
 Method in resource controller | [table](https://laravel.com/docs/master/controllers#resource-controllers) | store | ~~saveArticle~~
-Method in test class | camelCase | testGuestCannotSeeArticle | ~~test_guest_cannot_see_article~~
+Method in test class | snake_case | test_guest_cannot_see_article | ~~testGuestCannotSeeArticle~~
 Variable | camelCase | $articlesWithAuthor | ~~$articles_with_author~~
 Collection | descriptive, plural | $activeUsers = User::active()->get() | ~~$active, $data~~
 Object | descriptive, singular | $activeUser = User::active()->first() | ~~$users, $obj~~


### PR DESCRIPTION
Methods in test classes should probably use snake_case to maintain alignment with [official Laravel documentation](https://laravel.com/docs/9.x/testing) and all online tutorials (including all Laracast videos on tests).