### PR TITLE
Change test case methods to snake_case and mention Pest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Authorization | Policies | Entrust, Sentinel and other packages
 Compiling assets | Laravel Mix, Vite | Grunt, Gulp, 3rd party packages
 Development Environment | Laravel Sail, Homestead | Docker
 Deployment | Laravel Forge | Deployer and other solutions
-Unit testing | PHPUnit, Mockery | Phpspec, Pest
+Unit testing | PHPUnit, Pest, Mockery | Phpspec
 Browser testing | Laravel Dusk | Codeception
 DB | Eloquent | SQL, Doctrine
 Templates | Blade | Twig
@@ -520,7 +520,7 @@ Primary key | - | id | ~~custom_id~~
 Migration | - | 2017_01_01_000000_create_articles_table | ~~2017_01_01_000000_articles~~
 Method | camelCase | getAll | ~~get_all~~
 Method in resource controller | [table](https://laravel.com/docs/master/controllers#resource-controllers) | store | ~~saveArticle~~
-Method in test class | snake_case | test_guest_cannot_see_article | ~~testGuestCannotSeeArticle~~
+Method in PHPUnit test class | snake_case | test_guest_cannot_see_article | ~~testGuestCannotSeeArticle~~
 Variable | camelCase | $articlesWithAuthor | ~~$articles_with_author~~
 Collection | descriptive, plural | $activeUsers = User::active()->get() | ~~$active, $data~~
 Object | descriptive, singular | $activeUser = User::active()->first() | ~~$users, $obj~~

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Primary key | - | id | ~~custom_id~~
 Migration | - | 2017_01_01_000000_create_articles_table | ~~2017_01_01_000000_articles~~
 Method | camelCase | getAll | ~~get_all~~
 Method in resource controller | [table](https://laravel.com/docs/master/controllers#resource-controllers) | store | ~~saveArticle~~
-Method in test class | camelCase | testGuestCannotSeeArticle | ~~test_guest_cannot_see_article~~
+Method in test class | snake_case | test_guest_cannot_see_article | ~~testGuestCannotSeeArticle~~
 Variable | camelCase | $articlesWithAuthor | ~~$articles_with_author~~
 Collection | descriptive, plural | $activeUsers = User::active()->get() | ~~$active, $data~~
 Object | descriptive, singular | $activeUser = User::active()->first() | ~~$users, $obj~~


### PR DESCRIPTION
Update naming convention to match official Laravel documentation. (These "best practices" are currently out-of-step with modern Laravel standards.)

Reasoning:

 * Laravel [officially changed to snake_case](https://github.com/laravel/laravel/pull/5574) for test case methods in version 8.0. 
 * [Current Laravel documentation](https://laravel.com/docs/10.x/testing) uses snake_case. 
 * All [Laracast videos](https://laracasts.com/series/phpunit-testing-in-laravel/episodes/2) use snake_case. 
 * The [previous discussion's](https://github.com/alexeymezenin/laravel-best-practices/issues/28) reasoning to use camelCase for test case methods is no longer valid (aside from it not being PSR-12).
 
 