### PR TITLE
remove Pest from 3rd party packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Authorization | Policies | Entrust, Sentinel and other packages
 Compiling assets | Laravel Mix, Vite | Grunt, Gulp, 3rd party packages
 Development Environment | Laravel Sail, Homestead | Docker
 Deployment | Laravel Forge | Deployer and other solutions
-Unit testing | PHPUnit, Mockery | Phpspec, Pest
+Unit testing | PHPUnit, Mockery | Phpspec
 Browser testing | Laravel Dusk | Codeception
 DB | Eloquent | SQL, Doctrine
 Templates | Blade | Twig


### PR DESCRIPTION
Because Pest is used now in Laravel and also becomes part of it's documentation