### PR TITLE
Fix table of contents for "Use IoC / Service container instead of new Class"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Translations:
 
 [Use shorter and more readable syntax where possible](#use-shorter-and-more-readable-syntax-where-possible)
 
-[Use IoC container or facades instead of new Class](#use-ioc-container-or-facades-instead-of-new-class)
+[Use IoC / Service container instead of new Class](#use-ioc--service-container-instead-of-new-class)
 
 [Do not get data from the `.env` file directly](#do-not-get-data-from-the-env-file-directly)
 


### PR DESCRIPTION
- Fixed a broken TOC link.  
- Updated TOC entry to match the correct section title.  