### PR TITLE
Fix russian.md translation

### DIFF
--- a/russian.md
+++ b/russian.md
@@ -378,7 +378,7 @@ $users = User::with('profile')->get();
 
 ### **Используйте метод chunk при работе с большим количеством данных**
 
-Bad:
+Плохо:
 
 ```php
 $users = $this->get();
@@ -388,7 +388,7 @@ foreach ($users as $user) {
 }
 ```
 
-Good:
+Хорошо:
 
 ```php
 $this->chunk(500, function ($users) {


### PR DESCRIPTION
When translating into **Russian** in russian.md, they forgot to translate **English** words `Bad`, `Good` into **Russian** words `Плохо`, `Хорошо`.

This is the [place](https://github.com/alexeymezenin/laravel-best-practices/blob/master/russian.md#%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D1%83%D0%B9%D1%82%D0%B5-%D0%BC%D0%B5%D1%82%D0%BE%D0%B4-chunk-%D0%BF%D1%80%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%B5-%D1%81-%D0%B1%D0%BE%D0%BB%D1%8C%D1%88%D0%B8%D0%BC-%D0%BA%D0%BE%D0%BB%D0%B8%D1%87%D0%B5%D1%81%D1%82%D0%B2%D0%BE%D0%BC-%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85) (Practice: _Используйте метод chunk при работе с большим количеством данных_).